### PR TITLE
Update rto-edit.owl

### DIFF
--- a/src/ontology/rto-edit.owl
+++ b/src/ontology/rto-edit.owl
@@ -1,4 +1,3 @@
-
 Prefix(:=<http://purl.obolibrary.org/obo/rto.owl#>)
 Prefix(dce:=<http://purl.org/dc/elements/1.1/>)
 Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
@@ -10,35 +9,38 @@ Prefix(dcterms:=<http://purl.org/dc/terms/>)
 
 
 Ontology(<http://purl.obolibrary.org/obo/rto.owl>
-
-Import(<http://purl.obolibrary.org/obo/rto/imports/ro_import.owl>)
-
-Import(<http://purl.obolibrary.org/obo/rto/imports/iao_import.owl>)
-
+Import(<http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl>)
+Import(<http://purl.obolibrary.org/obo/ro/releases/2023-02-22/ro.owl>)
 Import(<http://purl.obolibrary.org/obo/rto/imports/bfo_import.owl>)
-
-Import(<http://purl.obolibrary.org/obo/rto/imports/ogms_import.owl>)
-
+Import(<http://purl.obolibrary.org/obo/rto/imports/iao_import.owl>)
 Import(<http://purl.obolibrary.org/obo/rto/imports/obi_import.owl>)
-
-
+Import(<http://purl.obolibrary.org/obo/rto/imports/ogms_import.owl>)
+Import(<http://purl.obolibrary.org/obo/rto/imports/ro_import.owl>)
 Annotation(dcterms:description "None")
 Annotation(dcterms:license <https://creativecommons.org/licenses/unspecified>)
 Annotation(dcterms:title "Radiation Therapy Ontology")
-
 
 Declaration(Class(<http://purl.obolibrary.org/obo/RTO_0000000>))
 Declaration(AnnotationProperty(dcterms:description))
 Declaration(AnnotationProperty(dcterms:license))
 Declaration(AnnotationProperty(dcterms:title))
-
 ############################
 #   Annotation Properties
 ############################
 
+# Annotation Property: dcterms:description (description)
+
 AnnotationAssertion(rdfs:label dcterms:description "description")
+
+# Annotation Property: dcterms:license (license)
+
 AnnotationAssertion(rdfs:label dcterms:license "license")
+
+# Annotation Property: dcterms:title (title)
+
 AnnotationAssertion(rdfs:label dcterms:title "title")
+
+
 
 ############################
 #   Classes
@@ -50,4 +52,3 @@ AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/RTO_0000000> "roo
 
 
 )
-


### PR DESCRIPTION
Within Protege, I used the Importing Ontologies mechanism to use OBO URL's for RO and BFO. Previously, rto-edit, looked to import folder within src folder  for import owl files.  These point to local repositories for RO and BFO.